### PR TITLE
use vEgo override cruise speed for toyota at min speed

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2209,4 +2209,5 @@ struct DragonConf {
   dpIsUpdating @72 :Bool;
   dpTimebombAssist @73 :Bool;
   dpDynamicGas @74 :Bool;
+  dpToyotaLowestCruiseOverrideVego @75 :Bool;
 }

--- a/common/dp_conf.py
+++ b/common/dp_conf.py
@@ -105,6 +105,7 @@ confs = [
   {'name': 'dp_toyota_sng', 'default': False, 'type': 'Bool', 'depends': [{'name': 'dp_car_detected', 'vals': ['toyota']}, {'name': 'dp_atl', 'vals': [False]}], 'conf_type': ['param', 'struct']},
   {'name': 'dp_toyota_zss', 'default': False, 'type': 'Bool', 'depends': [{'name': 'dp_car_detected', 'vals': ['toyota']}], 'conf_type': ['param']},
   {'name': 'dp_toyota_lowest_cruise_override', 'default': False, 'type': 'Bool', 'depends': [{'name': 'dp_car_detected', 'vals': ['toyota']}, {'name': 'dp_atl', 'vals': [False]}], 'conf_type': ['param', 'struct']},
+  {'name': 'dp_toyota_lowest_cruise_override_vego', 'default': False, 'type': 'Bool', 'depends': [{'name': 'dp_car_detected', 'vals': ['toyota']}, {'name': 'dp_atl', 'vals': [False]}], 'conf_type': ['param', 'struct']},
   {'name': 'dp_toyota_lowest_cruise_override_at', 'default': 44, 'type': 'Float32', 'depends': [{'name': 'dp_car_detected', 'vals': ['toyota']}, {'name': 'dp_toyota_lowest_cruise_override', 'vals': [True]}], 'min': 0, 'max': 255., 'conf_type': ['param', 'struct']},
   {'name': 'dp_toyota_lowest_cruise_override_speed', 'default': 32, 'type': 'Float32', 'depends': [{'name': 'dp_car_detected', 'vals': ['toyota']}, {'name': 'dp_toyota_lowest_cruise_override_speed', 'vals': [True]}], 'min': 0, 'max': 255., 'conf_type': ['param', 'struct']},
   #misc

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -11,6 +11,12 @@ from common.params import Params
 EventName = car.CarEvent.EventName
 
 class CarInterface(CarInterfaceBase):
+  def __init__(self, CP, CarController, CarState):
+    super().__init__(CP, CarController, CarState)
+
+    # dp
+    self.dp_cruise_speed = 0.
+
   @staticmethod
   def compute_gb(accel, speed):
     return float(accel) / 3.0
@@ -357,8 +363,16 @@ class CarInterface(CarInterfaceBase):
     # dp
     self.dragonconf = dragonconf
     ret.cruiseState.enabled = common_interface_atl(ret, dragonconf.dpAtl)
-    if dragonconf.dpToyotaLowestCruiseOverride and ret.cruiseState.speed < dragonconf.dpToyotaLowestCruiseOverrideAt * CV.KPH_TO_MS:
-      ret.cruiseState.speed = dragonconf.dpToyotaLowestCruiseOverrideSpeed * CV.KPH_TO_MS
+    if ret.cruiseState.enabled and dragonconf.dpToyotaLowestCruiseOverride and ret.cruiseState.speed < dragonconf.dpToyotaLowestCruiseOverrideAt * CV.KPH_TO_MS:
+      if dragonconf.dpToyotaLowestCruiseOverrideVego:
+        if self.dp_cruise_speed == 0.:
+          ret.cruiseState.speed = self.dp_cruise_speed = max( dragonconf.dpToyotaLowestCruiseOverrideSpeed * CV.KPH_TO_MS,ret.vEgo)
+        else:
+          ret.cruiseState.speed = self.dp_cruise_speed
+      else:
+        ret.cruiseState.speed = dragonconf.dpToyotaLowestCruiseOverrideSpeed * CV.KPH_TO_MS
+    else:
+      self.dp_cruise_speed = 0.
 
     ret.canValid = self.cp.can_valid and self.cp_cam.can_valid
     ret.steeringRateLimited = self.CC.steer_rate_limited if self.CC is not None else False


### PR DESCRIPTION
修改前dp开启dp_toyota_lowest_cruise_override的话，只能使用固定的dp_toyota_lowest_cruise_override_speed速度(一旦按+按键调整，又会回到原车45km/h)。显然在复杂的小路/弯路下一个固定的最小巡航速度是不够理想的。
参考@arne182的思路，在低于45km/h时，使用车辆当前速度做巡航速度(此特性有独立开关,原来的低速设定逻辑还保留)
[效果演示：](https://www.bilibili.com/video/BV1P54y1674i)
- 启用特性

#开启低速重写
echo -n 1 > /data/params/d/dp_toyota_lowest_cruise_override
#在上述条件下，开启使用当前速度做巡航速度
echo -n 1 > /data/params/d/dp_toyota_lowest_cruise_override_vego
#设定触发条件速度(以OP上看到的速度为准，可以稍微大0.x避免判断不准确)，低于该速度可以使用这个特性
echo -n 41.2 > /data/params/d/dp_toyota_lowest_cruise_override_at
#设定最低巡航速度 7km/h
echo -n 7 > /data/params/d/dp_toyota_lowest_cruise_override_speed

- 关闭当前速度做巡航速度特性
#关闭这个选项则功能跟原来的设定最低巡航速度效果一样
echo -n 0 > /data/params/d/dp_toyota_lowest_cruise_override_vego

- 关闭低速重写(系统默认)
echo -n 0 > /data/params/d/dp_toyota_lowest_cruise_override