### PR TITLE
fix for downgrading from 0.8.2

### DIFF
--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -87,6 +87,11 @@ def main(sm=None, pm=None):
     if params.get('carFingerprint', None) != CP.carFingerprint:
       cloudlog.info("Parameter learner found parameters for wrong car.")
       params = None
+  if params is not None:
+    if 'angleOffsetAverage' not in params:
+      if 'angleOffsetAverageDeg' in params:
+        params['angleOffsetAverage'] = params['angleOffsetAverageDeg']
+        params.pop('angleOffsetAverageDeg')
 
   if (params is not None) and not all((
       abs(params['angleOffsetAverage']) < 10.0,


### PR DESCRIPTION
When downgrading the newly named angleOffsetAverageDeg causes the paramsd to crash. This will copy over the value to old name of angleOffsetAverage.