### PR TITLE
Prius fix

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -363,9 +363,7 @@ class CarInterface(CarInterfaceBase):
     # dp
     ret = common_interface_get_params_lqr(ret)
     if candidate == CAR.PRIUS and Params().get('dp_toyota_zss') == b'1':
-      ret.mass = 3370. * CV.LB_TO_KG + STD_CARGO_KG
-      if Params().get('dp_lqr') == b'0':
-        ret.lateralTuning.indi.timeConstant = 0.1
+      ret.lateralTuning.indi.timeConstantV = [0.1]
       ret.steerRateCost = 0.5
 
     return ret


### PR DESCRIPTION
Fixed ZSS timeConstant, and removed LQR param which was causing “Openpilot unavailable, waiting for controls to start”. Also removed ret.mass change because it is meant for Prius Prime, not ZSS.