### PR TITLE
Re-tune DP Accel Profile

### DIFF
--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -42,14 +42,14 @@ DP_ACCEL_ECO = 0
 DP_ACCEL_NORMAL = 1
 DP_ACCEL_SPORT = 2
 
-# accel profile by @arne182
-_DP_CRUISE_MIN_V = [-2.0, -1.5, -1.0, -0.7, -0.5]
-_DP_CRUISE_MIN_V_ECO = [-1.0, -0.7, -0.6, -0.5, -0.3]
+# accel profile by @arne182 modified by @wer5lcy
+_DP_CRUISE_MIN_V = [-2.0, -1.8, -1.6, -1.4, -1.2]
+_DP_CRUISE_MIN_V_ECO = [-2.0, -1.6, -1.4, -1.2, -1.0]
 _DP_CRUISE_MIN_V_SPORT = [-3.0, -2.6, -2.3, -2.0, -1.0]
 _DP_CRUISE_MIN_BP = [0.0, 5.0, 10.0, 20.0, 55.0]
 
-_DP_CRUISE_MAX_V = [2.0, 2.0, 1.5, .5, .3]
-_DP_CRUISE_MAX_V_ECO = [0.8, 0.9, 1.0, 0.4, 0.2]
+_DP_CRUISE_MAX_V = [1.6, 1.4, 1.0, 0.6, 0.3]
+_DP_CRUISE_MAX_V_ECO = [1.5, 1.3, 0.8, 0.4, 0.2]
 _DP_CRUISE_MAX_V_SPORT = [3.0, 3.5, 3.0, 2.0, 2.0]
 _DP_CRUISE_MAX_BP = [0., 5., 10., 20., 55.]
 


### PR DESCRIPTION
Re-tune DP Accel Profile
Acceration profile is tuned to fit the 8ZR-FXE(aka ESTEC 2ZR-FXE) engine in Corolla Hybrid 2019 and Prius 4.
- The normal mode uses the whole ECO range, so that the engine won't roar.
- The eco mode uses 75% of the ECO range, providing best fuel effiency.
- The sport mode uses 80% of the full engine power. 
- The acceleration profile does not always work, my car could still accelerate from stop at 1.8m/s^2 without lead car.

Deceleration profile is changed such that the car could stop at static vehicles before traffic lights. 
- In previous version, using both accel profile "ECO" and following profile "1.2s" could cause your car unable to stop.
- The default max deceleration is 1.2m/s^2 in stock openpilot, any value in the custom profile should be no less than 1.2 unless necessary.