### PR TITLE
Increase braking to ISO 15622-2018; tune accelerating.

### DIFF
--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -43,13 +43,14 @@ DP_ACCEL_NORMAL = 1
 DP_ACCEL_SPORT = 2
 
 # accel profile by @arne182 modified by @wer5lcy
-_DP_CRUISE_MIN_V = [-2.0, -1.8, -1.6, -1.4, -1.2]
-_DP_CRUISE_MIN_V_ECO = [-2.0, -1.6, -1.4, -1.2, -1.0]
-_DP_CRUISE_MIN_V_SPORT = [-3.0, -2.6, -2.3, -2.0, -1.0]
-_DP_CRUISE_MIN_BP = [0.0, 5.0, 10.0, 20.0, 55.0]
+# leave braking to the model while adhereing ISO 15622-2018 @wer5lcy
+_DP_CRUISE_MIN_V = [-5.0, -5.0, -3.5, -3.5]
+_DP_CRUISE_MIN_V_ECO = [-5.0, -5.0, -3.5, -3.5]
+_DP_CRUISE_MIN_V_SPORT = [-5.0, -5.0, -3.5, -3.5]
+_DP_CRUISE_MIN_BP = [0.0, 5.0, 20.0, 55.0]
 
-_DP_CRUISE_MAX_V = [1.6, 1.4, 1.0, 0.6, 0.3]
-_DP_CRUISE_MAX_V_ECO = [1.5, 1.3, 0.8, 0.4, 0.2]
+_DP_CRUISE_MAX_V = [1.5, 1.3, 1.0, 0.6, 0.3]
+_DP_CRUISE_MAX_V_ECO = [1.2, 1.1, 0.8, 0.4, 0.2]
 _DP_CRUISE_MAX_V_SPORT = [3.0, 3.5, 3.0, 2.0, 2.0]
 _DP_CRUISE_MAX_BP = [0., 5., 10., 20., 55.]
 


### PR DESCRIPTION
I changed the DP acceleration profile in 0.8.8. After that, compared to stock openpilot acceleration profile, when using DP profiles, my car still occasionally unable to stop behind stationary cars. Therefore I increased decel curve to what ISO 15622-2018 writes, leaving braking to the model, and I've tested 300km. 

Please try this profile on your cars before merging. 