### PR TITLE
0.8.13 Add Support for Distance Button Control on Toyota TSS1 with SDSU

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -467,6 +467,7 @@ struct CarParams {
   radarTimeStep @45: Float32 = 0.05;  # time delta between radar updates, 20Hz is very standard
   fingerprintSource @49: FingerprintSource;
   networkLocation @50 :NetworkLocation;  # Where Panda/C2 is integrated into the car's CAN network
+  smartDsu @66: Bool;  # true if sDSU is detected
 
   wheelSpeedFactor @63 :Float32; # Multiplier on wheels speeds to computer actual speeds
 

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -45,7 +45,7 @@ class CarState(CarStateBase):
     # dp
     #self.read_distance_lines = 0
     #self.read_distance_lines_init = False
-    #self.distance = 0
+    self.distance = 0
     #self.read_lkas_btn = 0
     #self.read_lkas_btn_init = False
 
@@ -206,7 +206,10 @@ class CarState(CarStateBase):
 
     # dp
     # distance button
-    self.distance = 1 if cp_cam.vl["ACC_CONTROL"]["DISTANCE"] == 1 else 0
+    if self.CP.carFingerprint in TSS2_CAR:
+      self.distance = 1 if cp_cam.vl["ACC_CONTROL"]["DISTANCE"] == 1 else 0
+    elif self.CP.smartDsu:
+      self.distance = 1 if cp.vl["SDSU"]["FD_BUTTON"] == 1 else 0
     ret.distanceLines = cp.vl["PCM_CRUISE_SM"]["DISTANCE_LINES"]
     self._update_traffic_signals(cp_cam)
     ret.cruiseState.speedLimit = self._calculate_speed_limit()
@@ -399,6 +402,12 @@ class CarState(CarStateBase):
 
     if Params().get('dp_toyota_zss') == b'1':
       signals += [("ZORRO_STEER", "SECONDARY_STEER_ANGLE")]
+
+    # KRKeegan - Add support for toyota distance button
+    if CP.smartDsu:
+      signals.append(("FD_BUTTON", "SDSU", 0))
+      checks.append(("SDSU", 33))
+
 
     return CANParser(DBC[CP.carFingerprint]["pt"], signals, checks, 0)
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -252,13 +252,13 @@ class CarInterface(CarInterfaceBase):
 
     ret.enableBsm = 0x3F6 in fingerprint[0] and candidate in TSS2_CAR
     # Detect smartDSU, which intercepts ACC_CMD from the DSU allowing openpilot to send it
-    smartDsu = 0x2FF in fingerprint[0]
+    ret.smartDsu = 0x2FF in fingerprint[0]
     # In TSS2 cars the camera does long control
     found_ecus = [fw.ecu for fw in car_fw]
-    ret.enableDsu = (len(found_ecus) > 0) and (Ecu.dsu not in found_ecus) and (candidate not in NO_DSU_CAR) and (not smartDsu)
+    ret.enableDsu = (len(found_ecus) > 0) and (Ecu.dsu not in found_ecus) and (candidate not in NO_DSU_CAR) and (not ret.smartDsu)
     ret.enableGasInterceptor = 0x201 in fingerprint[0]
     # if the smartDSU is detected, openpilot can send ACC_CMD (and the smartDSU will block it from the DSU) or not (the DSU is "connected")
-    ret.openpilotLongitudinalControl = smartDsu or ret.enableDsu or candidate in TSS2_CAR
+    ret.openpilotLongitudinalControl = ret.smartDsu or ret.enableDsu or candidate in TSS2_CAR
     if Params().get_bool('dp_atl') and not Params().get_bool('dp_atl_op_long'):
       ret.openpilotLongitudinalControl = False
 


### PR DESCRIPTION
If self.distance is enabled and the vehicle has an SDSU, forward the FD_BUTTON bit to the vehicle to control the distance lines.

Note this will require that the SDSU has at least this firmware on it, in order for the ditance button signal to be forwarded:
wocsor/panda@b5120f6

Original author: krkeegan & sshane