### PR TITLE
fix update_dp_set_offsets()

### DIFF
--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -45,26 +45,15 @@ class LanePlanner:
     self.camera_offset = -CAMERA_OFFSET if wide_camera else CAMERA_OFFSET
     self.path_offset = -PATH_OFFSET if wide_camera else PATH_OFFSET
 
-    self.dp_camera_offset = None
-    self.dp_path_offset = None
     self.dp_wide_camera = wide_camera
 
-  def update_dp_set_offsets(self, camera_offset, path_offset):
-    if self.dp_camera_offset != camera_offset:
-      self.dp_camera_offset = camera_offset
-      # from -0.04 to 0.04, difference is 0.08
-      # so we can assume the distance between C3's 2 cameras is 8 cm
-      if self.dp_wide_camera:
-        self.camera_offset += 8
-      self.camera_offset = camera_offset / 100
-
-    if self.dp_path_offset != path_offset:
-      self.dp_path_offset = path_offset
-      # from -0.04 to 0.04, difference is 0.08
-      # so we can assume the distance between C3's 2 cameras is 8 cm
-      if self.dp_wide_camera:
-        self.dp_path_offset += 8
-      self.path_offset = path_offset / 100
+  def update_dp_set_offsets(self, camera_offset, path_offset):    
+    camera_offset = -camera_offset    
+    path_offset = -path_offset        
+    # from 0.04 to -0.04, difference is -0.08
+    # so we can assume the distance between C3's 2 cameras is 8 cm
+    self.camera_offset = (camera_offset - 8) * 0.01 if self.dp_wide_camera else camera_offset * 0.01
+    self.path_offset = (path_offset - 8) * 0.01 if self.dp_wide_camera else path_offset * 0.01
 
   def parse_model(self, md):
     lane_lines = md.laneLines


### PR DESCRIPTION
CAMERA_OFFSET and PATH_OFFSET usages are different between v0.8.12 and  v0.8.13.

*update_dp_set_offsets() also need modification if don't change params.

*bug fix for dp_wide_camera

v0.8.12

if EON:
  CAMERA_OFFSET = 0.06
  PATH_OFFSET = 0.0
elif TICI:
  CAMERA_OFFSET = -0.04
  PATH_OFFSET = -0.04
else:
  CAMERA_OFFSET = 0.0
  PATH_OFFSET = 0.0


v0.8.13

if EON:
  CAMERA_OFFSET = -0.06
  PATH_OFFSET = 0.0
elif TICI:
  CAMERA_OFFSET = 0.04
  PATH_OFFSET = 0.04
else:
  CAMERA_OFFSET = 0.0
  PATH_OFFSET = 0.0