### PR TITLE
rewrite and fix update_dp_set_offsets()

### DIFF
--- a/common/dp_conf.py
+++ b/common/dp_conf.py
@@ -4,7 +4,7 @@ import sys
 import json
 import time
 from math import floor
-from selfdrive.hardware import TICI
+from selfdrive.hardware import EON, TICI
 
 '''
 * type: Bool, Int8, UInt8, UInt16, Float32
@@ -86,8 +86,8 @@ confs = [
   {'name': 'dp_ip_addr', 'default': '', 'type': 'Text', 'conf_type': ['struct']},
   {'name': 'dp_fan_mode', 'default': 0, 'type': 'UInt8', 'min': 0, 'max': 2, 'conf_type': ['param']},
   {'name': 'dp_last_modified', 'default': str(floor(time.time())), 'type': 'Text', 'conf_type': ['param']},
-  {'name': 'dp_camera_offset', 'default': -4 if TICI else 6, 'type': 'Int8', 'min': -100, 'max': 100, 'conf_type': ['param', 'struct']},
-  {'name': 'dp_path_offset', 'default': -4 if TICI else 0, 'type': 'Int8', 'min': -100, 'max': 100, 'conf_type': ['param', 'struct']},
+  {'name': 'dp_camera_offset', 'default': 6 if EON else -4 if TICI else 0, 'type': 'Int8', 'min': -100, 'max': 100, 'conf_type': ['param', 'struct']},
+  {'name': 'dp_path_offset', 'default': 0 if EON else -4 if TICI else 0, 'type': 'Int8', 'min': -100, 'max': 100, 'conf_type': ['param', 'struct']},
 
   {'name': 'dp_locale', 'default': 'en-US', 'type': 'Text', 'conf_type': ['param', 'struct'], 'update_once': True},
   {'name': 'dp_reg', 'default': False, 'type': 'Bool', 'conf_type': ['param']},

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -45,26 +45,15 @@ class LanePlanner:
     self.camera_offset = -CAMERA_OFFSET if wide_camera else CAMERA_OFFSET
     self.path_offset = -PATH_OFFSET if wide_camera else PATH_OFFSET
 
-    self.dp_camera_offset = None
-    self.dp_path_offset = None
     self.dp_wide_camera = wide_camera
 
   def update_dp_set_offsets(self, camera_offset, path_offset):
-    if self.dp_camera_offset != camera_offset:
-      self.dp_camera_offset = camera_offset
-      # from -0.04 to 0.04, difference is 0.08
-      # so we can assume the distance between C3's 2 cameras is 8 cm
-      if self.dp_wide_camera:
-        self.camera_offset += 8
-      self.camera_offset = camera_offset / 100
-
-    if self.dp_path_offset != path_offset:
-      self.dp_path_offset = path_offset
-      # from -0.04 to 0.04, difference is 0.08
-      # so we can assume the distance between C3's 2 cameras is 8 cm
-      if self.dp_wide_camera:
-        self.dp_path_offset += 8
-      self.path_offset = path_offset / 100
+    camera_offset = -camera_offset    
+    path_offset = -path_offset        
+    # from 0.04 to -0.04, difference is -0.08
+    # so we can assume the distance between C3's 2 cameras is 8 cm
+    self.camera_offset = (camera_offset - 8) * 0.01 if self.dp_wide_camera else camera_offset * 0.01
+    self.path_offset = (path_offset - 8) * 0.01 if self.dp_wide_camera else path_offset * 0.01
 
   def parse_model(self, md):
     lane_lines = md.laneLines


### PR DESCRIPTION
CAMERA_OFFSET and PATH_OFFSET usages are different between v0.8.12 and  v0.8.13.

*update_dp_set_offsets() also need modification if don't change params.

*rewrite update_dp_set_offsets()

- fix bug for wide_camera
-  tune dp_conf.py (dp_camera_offset and dp_path_offset) for not TICI nor EON
-  prepare for upcoming OP v0.8.14 bigmodel with wide camera
-  easy to read and maintain
  (syntax is the same with stock OP)
- computer usually run multiply faster than divide (not sure about python)

Please see attached pdf for code tracing
[fix offset.pdf](https://github.com/dragonpilot-community/dragonpilot/files/8470284/fix.offset.pdf)

