### PR TITLE
default ret.steerRateCost should before candidates

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -33,7 +33,7 @@ class CarInterface(CarInterfaceBase):
     ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
     ret.steerLimitTimer = 0.4
     ret.stoppingControl = False  # Toyota starts braking more when it thinks you want to stop
-
+    ret.steerRateCost = 1.
     stop_and_go = False
 
     if candidate == CAR.PRIUS:
@@ -238,7 +238,7 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 4070 * CV.LB_TO_KG + STD_CARGO_KG
       set_lat_tune(ret.lateralTuning, LatTunes.PID_L)
 
-    ret.steerRateCost = 1.
+
     ret.centerToFront = ret.wheelbase * 0.44
 
     # TODO: get actual value, for now starting with reasonable value for


### PR DESCRIPTION
default ret.steerRateCost should before candidates,
otherwise it will overwrite candidate specific parameter .

for example , it overwirte ret.steerRateCost of PRIUS_TSS2