### PR TITLE
Fine tune lateral_planner.py

### DIFF
--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -66,7 +66,7 @@ class LateralPlanner:
     self.d_path_w_lines_xyz = self.LP.get_d_path(v_ego, self.t_idxs, self.path_xyz)
 
     # Calculate final driving path and set MPC costs
-    if not self.get_dlp_laneless_mode():
+    if self.dlp_use_lanelines():
       d_path_xyz = self.d_path_w_lines_xyz
       self.lat_mpc.set_weights(MPC_COST_LAT.PATH, MPC_COST_LAT.HEADING, self.steer_rate_cost)
       self.laneless_mode_is_e2e = False
@@ -107,11 +107,11 @@ class LateralPlanner:
     else:
       self.solution_invalid_cnt = 0
 
-  def get_dlp_laneless_mode(self):
+  def dlp_use_lanelines(self):
     if self.laneless_mode == 1: # e2e
-      return True
-    if self.laneless_mode == 0: # lane
       return False
+    if self.laneless_mode == 0: # lane
+      return True
     elif self.laneless_mode == 2: # auto
       # only while lane change is off
       if self.DH.desire == log.LateralPlan.Desire.none:
@@ -120,9 +120,9 @@ class LateralPlanner:
           self.laneless_mode_buffer = True
         if (self.LP.lll_prob + self.LP.rll_prob)/2 > 0.5:
           self.laneless_mode_buffer = False
-        if self.laneless_mode_buffer: # in buffer mode, always laneless
-          return True
-    return False
+        if self.laneless_mode_buffer: # in buffer mode, don't use lanelines
+          return False
+    return True
 
   def publish(self, sm, pm):
     plan_solution_valid = self.solution_invalid_cnt < 2


### PR DESCRIPTION
Fine tune lateral_planner.py in order to
* remove unnecessary "not" process
* keep same logic with stock Openpilot
* easy to understand and handle conflict in the future
* please feel free to modify "dlp_use_lanelines" according naming convention you are used to

https://github.com/commaai/openpilot/blob/v0.8.13/selfdrive/controls/lib/lateral_planner.py#L60

![image](https://user-images.githubusercontent.com/93507091/166170532-84fc38e7-5ef2-46c7-b583-01b4972895d3.png)


