### PR TITLE
Enable subaru support for PREGLOBAL cars

### DIFF
--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -22,7 +22,7 @@ class CarInterface(CarInterfaceBase):
       ret.safetyConfigs = [get_safety_config(car.CarParams.SafetyModel.subaru)]
       ret.enableBsm = 0x228 in fingerprint[0]
 
-    ret.dashcamOnly = candidate in PREGLOBAL_CARS
+    #ret.dashcamOnly = candidate in PREGLOBAL_CARS
 
     ret.steerRateCost = 0.7
     ret.steerLimitTimer = 0.4


### PR DESCRIPTION
CAR.FORESTER_PREGLOBAL, CAR.LEGACY_PREGLOBAL, CAR.OUTBACK_PREGLOBAL, CAR.OUTBACK_PREGLOBAL_2018

These cars will go into dashcam mode by default .
This line is hashed in dp0810 and dp0812