### PR TITLE
remove low speed alert

### DIFF
--- a/selfdrive/car/mazda/carstate.py
+++ b/selfdrive/car/mazda/carstate.py
@@ -14,7 +14,6 @@ class CarState(CarStateBase):
 
     self.crz_btns_counter = 0
     self.acc_active_last = False
-    self.low_speed_alert = False
     self.lkas_allowed_speed = False
     self.lkas_disabled = False
 
@@ -81,12 +80,6 @@ class CarState(CarStateBase):
     # dp
     ret.cruiseActualEnabled = ret.cruiseState.enabled
     ret.cruiseState.speed = self.cruise_speed
-
-    if ret.cruiseState.enabled:
-      if not self.lkas_allowed_speed and self.acc_active_last:
-        self.low_speed_alert = True
-      else:
-        self.low_speed_alert = False
 
     # Check if LKAS is disabled due to lack of driver torque when all other states indicate
     # it should be enabled (steer lockout). Don't warn until we actually get lkas active

--- a/selfdrive/car/mazda/interface.py
+++ b/selfdrive/car/mazda/interface.py
@@ -96,9 +96,7 @@ class CarInterface(CarInterfaceBase):
 
     if self.CS.lkas_disabled:
       events.add(EventName.lkasDisabled)
-    elif self.CS.low_speed_alert:
-      events.add(EventName.belowSteerSpeed)
-
+      
     ret.events = events.to_msg()
 
     self.CS.out = ret.as_reader()


### PR DESCRIPTION
the `low_speed_alert` result in a constant alert showing on the screen for Mazda cx5 2022. remove it for better user experience