### PR TITLE
Feature requests

### DIFF
--- a/selfdrive/controls/lib/speed_limit_controller.py
+++ b/selfdrive/controls/lib/speed_limit_controller.py
@@ -12,11 +12,14 @@ from selfdrive.modeld.constants import T_IDXS
 
 
 _PARAMS_UPDATE_PERIOD = 2.  # secs. Time between parameter updates.
-_TEMP_INACTIVE_GUARD_PERIOD = 1.  # secs. Time to wait after activation before considering temp deactivation signal.
+_TEMP_INACTIVE_GUARD_PERIOD = 10000.  # secs. Time to wait after activation before considering temp deactivation signal.
 
 # Lookup table for speed limit percent offset depending on speed.
-_LIMIT_PERC_OFFSET_V =  [ 0.0,  0.1, 0.14, 0.11,  0.2,  0.18, 0.17, 0.14, 0.065,  0.0] # 20, 33, 40, 50, 65, 75, 80, 80, 80 mph
-_LIMIT_PERC_OFFSET_BP = [11.0, 13.4, 15.6, 20.1, 22.3, 24.58, 29.0, 31.2,  33.4, 35.7] # 20, 30, 35, 45, 55, 65, 70, 75, 80 mph
+#_LIMIT_PERC_OFFSET_V =  [ 0.0,  0.1, 0.14, 0.11,  0.2,  0.18, 0.17, 0.14, 0.065,  0.0] # 20, 33, 40, 50, 65, 75, 80, 80, 80 mph
+#_LIMIT_PERC_OFFSET_BP = [11.0, 13.4, 15.6, 20.1, 22.3, 24.58, 29.0, 31.2,  33.4, 35.7] # 20, 30, 35, 45, 55, 65, 70, 75, 80 mph
+_LIMIT_PERC_OFFSET_V = [0.316, 0.19, 0.133, 0.118, 0.105, 0.095, 0.455, 0.24, 0.21]
+_LIMIT_PERC_OFFSET_BP = [6.7, 11.18, 15.8, 17.88, 20.12, 22.35, 24.58, 26.8, 31.29]
+
 
 SpeedLimitControlState = log.LongitudinalPlan.SpeedLimitControlState
 EventName = car.CarEvent.EventName


### PR DESCRIPTION
Feature requests:
-via UI, always on mapd by editing temp inactive guard timer selection from 1 second to 10,000 in speed_limit_controller.py because if timer is too low it causes mapd engagement interference while increasing set speed. Suggested by Alfern from move fast and verified to work by over 15k miles of test drives 
-via UI, edit speed limit offset above and below 55mph, for example "5mph below 55mph" and 15mph above 55mph because the flow of traffic differs between locations and if RSA picks up 55mph speed limit on freeway it causes a false positive. I use the following offset: ``_LIMIT_PERC_OFFSET_V = [0.316, 0.19, 0.133, 0.118, 0.105, 0.095, 0.455, 0.24, 0.21] _LIMIT_PERC_OFFSET_BP = [6.7, 11.18, 15.8, 17.88, 20.12, 22.35, 24.58, 26.8, 31.29]`` -via corolla2020 follow mode wheel button, DE2E on/off by holding FM button because it still stops at crosswalks and is not good enough to stay on. Thanks for your consideration!